### PR TITLE
Add ability to rename pads, issue #77

### DIFF
--- a/Source/BuildWindow.cs
+++ b/Source/BuildWindow.cs
@@ -220,6 +220,10 @@ namespace ExLP {
 			}
 		}
 
+		static public void updateCurrentPads() {
+			instance.BuildPadList (FlightGlobals.ActiveVessel);
+		}
+
 		void UpdateGUIState ()
 		{
 			enabled = !hide_ui && launchpads != null && gui_enabled;


### PR DESCRIPTION
Right-click on pad to rename.  Also shows current name in right-click menu.

![renamepad](https://cloud.githubusercontent.com/assets/5103358/5532400/74098eda-8a3f-11e4-97da-8c6f1c3f534b.png)
