### PR TITLE
Allow MetalOre on asteroids

### DIFF
--- a/GameData/ExtraplanetaryLaunchpads/Resources/Asteroid_MetalOre.cfg
+++ b/GameData/ExtraplanetaryLaunchpads/Resources/Asteroid_MetalOre.cfg
@@ -9,7 +9,7 @@
     }
 }
 
-@PART[SurfaceScanner] {
+@PART[SurfaceScanner]:FOR[ExtraplanetaryLaunchpads] {
     MODULE {
         name = ModuleAnalysisResource
         resourceName = MetalOre

--- a/GameData/ExtraplanetaryLaunchpads/Resources/Asteroid_MetalOre.cfg
+++ b/GameData/ExtraplanetaryLaunchpads/Resources/Asteroid_MetalOre.cfg
@@ -13,6 +13,5 @@
     MODULE {
         name = ModuleAnalysisResource
         resourceName = MetalOre
-        abundance = 0
     }
 }

--- a/GameData/ExtraplanetaryLaunchpads/Resources/Asteroid_MetalOre.cfg
+++ b/GameData/ExtraplanetaryLaunchpads/Resources/Asteroid_MetalOre.cfg
@@ -1,0 +1,18 @@
+@PART[PotatoRoid]:FOR[ExtraplanetaryLaunchpads] {
+    MODULE
+    {
+        name = ModuleAsteroidResource
+        resourceName = MetalOre
+        presenceChance = 80
+        lowRange = 50
+        highRange = 75
+    }
+}
+
+@PART[SurfaceScanner] {
+    MODULE {
+        name = ModuleAnalysisResource
+        resourceName = MetalOre
+        abundance = 0
+    }
+}


### PR DESCRIPTION
This config gives MetalOre the same distribution on asteroids as MKS MetallicOre.

No new drill is required because on asteroids, the stock drill mines all resources that are present.